### PR TITLE
`is_ordered` changes

### DIFF
--- a/jsonmatch/matcher.py
+++ b/jsonmatch/matcher.py
@@ -60,7 +60,7 @@ class JsonMatcher(object):
             print bs.breaks_str
             raise AssertionError(msg)
 
-    def breaks(self, test_d, is_ordered=True):
+    def breaks(self, test_d, is_ordered=False):
         """
         Return None if `test_d` is an acceptable match to `self.spec`,
         Breaks object otherwise.
@@ -202,7 +202,7 @@ class JsonMatcher(object):
         index."""
         seq = seq or []
 
-        if is_ordered:
+        if not is_ordered:
             seq = sorted(seq)
 
         return dict(zip(range(len(seq)), seq))

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -105,6 +105,7 @@ class TestMatch(unittest.TestCase):
 
     def test_unordered(self):
         """Ensure unordered matches work."""
+        self.spec['c']['e'] = [1, 2, 3]
         badd = dict(self.matchingd)
         badd['c']['e'] = [3, 1, 2]
 


### PR DESCRIPTION
This is a possible breaking change.

If someone previously use `is_ordered=True` explicitly to ignore ordering, this will break their test cases.

e.g.

``` python
import jsonmatch
a = [1, 2, 3]
b = [3, 2, 1]
matcher = jsonmatch.compile(a)
matcher.assert_matches(b, is_ordered=True)
```

Not sure if it is worth to update the code to match up with the doc. If we update doc to match with the code, then we won't break any codes that rely on this behavior.
